### PR TITLE
Updated splash page assets

### DIFF
--- a/_layouts/layout-splashpage.html
+++ b/_layouts/layout-splashpage.html
@@ -43,7 +43,7 @@
 					<h1 property="name" class="wb-inv">{{ page.title }}</h1>
 					<div class="row">
 						<div class="col-xs-11 col-md-8" property="publisher" resource="#wb-publisher" typeof="GovernmentOrganization">
-							<img src="{{ setting-resourcesBasePathTheme }}/assets/sig-spl.svg" width="283" alt="Government of Canada" property="logo" /><span class="wb-inv"> / <span lang="fr">Gouvernement du Canada</span></span>
+							<img src="https://www.nrcan.gc.ca/sites/all/themes/canadaca/assets/NRCan.svg" width="283" alt="Natural Resources Canada / Ressources naturelles Canada" property="logo" /><span class="wb-inv"> / <span lang="fr">Gouvernement du Canada</span></span>
 							<meta property="name" content="Government of Canada" />
 							<meta property="areaServed" typeOf="Country" content="Canada" />
 						</div>
@@ -58,7 +58,7 @@
 							<a href="https://www.canada.ca/en/transparency/terms.html" class="sp-lk">Terms and conditions</a> <span class="glyphicon glyphicon-asterisk"></span> <a href="https://www.canada.ca/fr/transparence/avis.html" class="sp-lk" lang="fr">Avis</a>
 						</div>
 						<div class="col-xs-5 col-md-4 text-right mrgn-bttm-md">
-							<img src="{{ setting-resourcesBasePathTheme }}/assets/wmms-spl.svg" width="127" alt="Symbol of the Government of Canada" /><span class="wb-inv"> / <span lang="fr">Symbole du gouvernement du Canada</span></span>
+							<img src="https://www.nrcan.gc.ca/sites/all/libraries/canadaca/GCWeb/assets/wmms-spl.svg" width="127" alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada" /><span class="wb-inv"> / <span lang="fr">Symbole du gouvernement du Canada</span></span>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Updated the splash page to match https://www.nrcan.gc.ca/ and use those assets, as existing ones are down.