### PR TITLE
Add {en,fr}/psra.html redirection links to avoid 404 error

### DIFF
--- a/_pages/en/psra.html
+++ b/_pages/en/psra.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Redirecting to https://opendrr.github.io/seismic-risk-model/en/index.html</title>
+<meta http-equiv="refresh" content="3; URL=https://opendrr.github.io/seismic-risk-model/en/index.html">
+<link rel="canonical" href="https://opendrr.github.io/seismic-risk-model/en/index.html">
+</head>
+<body>
+<p>Redirecting to <a href="https://opendrr.github.io/seismic-risk-model/en/index.html">https://opendrr.github.io/seismic-risk-model/en/index.html</a>…</p>
+</body>
+</html>

--- a/_pages/fr/psra.html
+++ b/_pages/fr/psra.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Redirection vers https://opendrr.github.io/seismic-risk-model/fr/index.html</title>
+<meta http-equiv="refresh" content="3; URL=https://opendrr.github.io/seismic-risk-model/fr/index.html">
+<link rel="canonical" href="https://opendrr.github.io/seismic-risk-model/fr/index.html">
+</head>
+<body>
+<p>Redirection vers <a href="https://opendrr.github.io/seismic-risk-model/fr/index.html">https://opendrr.github.io/seismic-risk-model/fr/index.html</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
The October 2022 soft-launch release of https://www.riskprofiler.ca/download-data/index.html still refers to the old link https://opendrr.github.io/downloads/en/psra.html instead of the new page https://opendrr.github.io/seismic-risk-model/en/index.html due to my oversight.  (Sorry!)

Many thanks!